### PR TITLE
Fix invalid color hex code

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,7 +30,7 @@ export default {
 					secondaryLilac: '#DE9DFD', // Lilac
 					secondaryYellow: '#FDB4D1', // Yellow
 					secondaryRed: '#EE4B3C', // Red
-					secondaryBlue: '#1873C', // Blue
+                                        secondaryBlue: '#1873CF', // Blue
 					secondaryGreen: '#1FA849', // Green
 					secondaryPeach: '#F9B6B0', // Peach
 					neonGreen: '#d2fb55', // Neon Green


### PR DESCRIPTION
## Summary
- fix invalid hex color value in tailwind config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fa12f88e48330ac5c6dafaf732393